### PR TITLE
Fixed Dangerous Printf Wrong Arguments And Changing Branch Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Set the minimum version of CMake
 cmake_minimum_required(VERSION 3.10.0)
-project(Virtual_Processing_Unit VERSION 1.3.4 LANGUAGES C CXX)
+project(Virtual_Processing_Unit VERSION 1.3.5 LANGUAGES C CXX)
 
 
 add_executable(compile src/compiler.c)

--- a/examples/hello_world.txt
+++ b/examples/hello_world.txt
@@ -5,7 +5,7 @@ SYS  0
 
 MOVV RE 1
 
-
+MOVV RC 0
 
 loop:
 

--- a/src/core.h
+++ b/src/core.h
@@ -37,10 +37,8 @@ typedef enum OpCode{
     INST_MOVN,
     // moves an immediate value directly into the first 16 bits of a register
     INST_MOVV16,
-    // pushes a value from a register to the stack
+    // pushes a 64 bit value to the stack
     INST_PUSH,
-    // pushes a 64 bit value directly to the stack
-    INST_PUSHV,
     // pops a 64 bit value from the stack into a register
     INST_POP,
     // reads a 64 bit value from the stack into a register
@@ -155,8 +153,6 @@ typedef enum OpProfile{
     OP_PROFILE_NONE = EXPECT_ANY,
     // instruction takes one register
     OP_PROFILE_R = EXPECT_OP_REG,
-    // instruction takes one literal
-    OP_PROFILE_L = EXPECT_OP_LIT,
     // instruction takes either a literal or a register
     OP_PROFILE_E = EXPECT_OP_EITHER,
     // instruction takes two registers
@@ -225,6 +221,7 @@ typedef struct VPU
     
 } VPU;
 
+#define GET_OP_HINT(INST) (INST >> 31)
 
 static inline int is_little_endian(){ return (*(unsigned short *)"\x01\x00" == 0x01); }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -63,13 +63,12 @@ InstProfile get_inst_profile(const Token inst_token){
     if(COMP_TKN(inst_token, MKTKN("MOVV")))   return (InstProfile){INST_MOVV  , OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("MOVN")))   return (InstProfile){INST_MOVN  , OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("MOVV16"))) return (InstProfile){INST_MOVV16, OP_PROFILE_RL};
-    if(COMP_TKN(inst_token, MKTKN("PUSH")))   return (InstProfile){INST_PUSH  , OP_PROFILE_R};
-    if(COMP_TKN(inst_token, MKTKN("PUSHV")))  return (InstProfile){INST_PUSHV , OP_PROFILE_L};
+    if(COMP_TKN(inst_token, MKTKN("PUSH")))   return (InstProfile){INST_PUSH  , OP_PROFILE_E};
     if(COMP_TKN(inst_token, MKTKN("POP")))    return (InstProfile){INST_POP   , OP_PROFILE_R};
     if(COMP_TKN(inst_token, MKTKN("GET")))    return (InstProfile){INST_GET   , OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("WRITE")))  return (InstProfile){INST_WRITE , OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("GSP")))    return (InstProfile){INST_GSP   , OP_PROFILE_R};
-    if(COMP_TKN(inst_token, MKTKN("STATIC"))) return (InstProfile){INST_STATIC, OP_PROFILE_L};
+    if(COMP_TKN(inst_token, MKTKN("STATIC"))) return (InstProfile){INST_STATIC, OP_PROFILE_E};
     if(COMP_TKN(inst_token, MKTKN("READ8")))  return (InstProfile){INST_READ8 , OP_PROFILE_RR};
     if(COMP_TKN(inst_token, MKTKN("READ16"))) return (InstProfile){INST_READ16, OP_PROFILE_RR};
     if(COMP_TKN(inst_token, MKTKN("READ32"))) return (InstProfile){INST_READ32, OP_PROFILE_RR};
@@ -86,7 +85,7 @@ InstProfile get_inst_profile(const Token inst_token){
     if(COMP_TKN(inst_token, MKTKN("OR")))     return (InstProfile){INST_OR    , OP_PROFILE_RR};
     if(COMP_TKN(inst_token, MKTKN("XOR")))    return (InstProfile){INST_XOR   , OP_PROFILE_RR};
     if(COMP_TKN(inst_token, MKTKN("BSHIFT"))) return (InstProfile){INST_BSHIFT, OP_PROFILE_RR};
-    if(COMP_TKN(inst_token, MKTKN("JMP")))    return (InstProfile){INST_JMP   , OP_PROFILE_L};
+    if(COMP_TKN(inst_token, MKTKN("JMP")))    return (InstProfile){INST_JMP   , OP_PROFILE_E};
     if(COMP_TKN(inst_token, MKTKN("JMPF")))   return (InstProfile){INST_JMPIF , OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("JMPFN")))  return (InstProfile){INST_JMPIFN, OP_PROFILE_RL};
     if(COMP_TKN(inst_token, MKTKN("CALL")))   return (InstProfile){INST_CALL  , OP_PROFILE_E};
@@ -137,7 +136,7 @@ InstProfile get_inst_profile(const Token inst_token){
     if(COMP_TKN(inst_token, MKTKN("PUTC")))   return (InstProfile){INST_PUTC  , OP_PROFILE_RR};
     if(COMP_TKN(inst_token, MKTKN("GETC")))   return (InstProfile){INST_GETC  , OP_PROFILE_R};
 
-    if(COMP_TKN(inst_token, MKTKN("SYS")))    return (InstProfile){INST_SYS   , OP_PROFILE_L};
+    if(COMP_TKN(inst_token, MKTKN("SYS")))    return (InstProfile){INST_SYS   , OP_PROFILE_E};
     if(COMP_TKN(inst_token, MKTKN("DISREG"))) return (InstProfile){INST_DISREG, OP_PROFILE_R};
 
     return (InstProfile){INST_ERROR, 0};
@@ -460,8 +459,8 @@ int parse_inst(Parser* parser, Mc_stream_t* static_memory, Mc_stream_t* program,
                 const uint64_t op_value = static_memory->size;
                 mc_stream(static_memory, token.value.as_str + 1, token.size - 2);
                 mc_stream_str(static_memory, "");
-                inst |= (op_value & 0XFFFFFF) << 8;
-                inst |= HINT_LIT << 24;
+                inst |= (op_value & 0XFFFF) << 8;
+                inst |= HINT_LIT << 31;
                 op_token_pos += 1;
                 op_pos_in_inst += 3;
                 break;
@@ -482,13 +481,13 @@ int parse_inst(Parser* parser, Mc_stream_t* static_memory, Mc_stream_t* program,
                     return 1;
                 }
                 inst |= operand.value.as_uint16 << (8 * op_pos_in_inst);
-                inst |= HINT_LIT << 24;
+                inst |= HINT_LIT << 31;
                 op_pos_in_inst += 3;
                 op_token_pos += 1;
                 break;
             }
             inst |= (reg << (op_pos_in_inst * 8));
-            inst |= HINT_REG << 24;
+            inst |= HINT_REG << 31;
             op_pos_in_inst += 3;
             op_token_pos += 1;
         }   break;

--- a/src/vpu.c
+++ b/src/vpu.c
@@ -42,7 +42,7 @@ static inline int64_t perform_inst(Inst inst){
     case INST_NOP:
         return 1;
     case INST_HALT:
-        vpu.return_status = ((inst >> 24) == HINT_REG)? (int) R1.as_int64 : (int) L1;
+        vpu.return_status = (GET_OP_HINT(inst) == HINT_REG)? (int) R1.as_int64 : (int) L1;
         return 0XFFFFFFFFFFFFFFFF - IP;
     case INST_MOV8:
         R1.as_uint8 = R2.as_uint8;
@@ -69,11 +69,8 @@ static inline int64_t perform_inst(Inst inst){
         R1.as_uint16 = L2;
         return 1;
     case INST_PUSH:
-        vpu.stack[SP++] = R1.as_uint64;
+        vpu.stack[SP++] = (GET_OP_HINT(inst) == HINT_REG)? R1.as_uint64 : L1;
         return 1;
-    case INST_PUSHV:
-        vpu.stack[SP++] = L1;
-       return 1;
     case INST_POP:
         R1.as_uint64 = vpu.stack[--SP];
         return 1;
@@ -87,7 +84,7 @@ static inline int64_t perform_inst(Inst inst){
         R1.as_ptr = vpu.stack;
         return 1;
     case INST_STATIC:
-        vpu.stack[SP++] = (uint64_t)(uintptr_t)(vpu.static_memory + L1);
+        vpu.stack[SP++] = (uint64_t)(uintptr_t)(vpu.static_memory + ((GET_OP_HINT(inst) == HINT_REG)? R1.as_uint64 : L1));
         return 1;
     case INST_READ8:
         R1.as_uint8 = *(uint8_t*)(R2.as_ptr);
@@ -138,7 +135,7 @@ static inline int64_t perform_inst(Inst inst){
         R1.as_uint64 = R2.as_int64 < 0? R1.as_uint64 >> -(R2.as_int64) : R1.as_uint64 << R2.as_uint64;
         return 1;
     case INST_JMP:
-        IP = L1;
+        IP = (GET_OP_HINT(inst) == HINT_REG)? R1.as_uint64 : L1;
         return 1;
     case INST_JMPIF:
         if(R1.as_uint64){
@@ -154,7 +151,7 @@ static inline int64_t perform_inst(Inst inst){
         return 1;
     case INST_CALL:
         vpu.stack[SP++] = IP + 1;
-        IP = ((inst >> 24) == HINT_REG)? R1.as_uint64 : L1;
+        IP = (GET_OP_HINT(inst) == HINT_REG)? R1.as_uint64 : L1;
         return 0;
     case INST_RET:
         IP = vpu.stack[--SP];
@@ -325,9 +322,11 @@ static inline int64_t perform_inst(Inst inst){
     
 
     case INST_SYS:
-        if(sys_call(&vpu, L1)){
-            exit(1);
-        }
+        if(sys_call(&vpu, (GET_OP_HINT(inst) == HINT_REG)? R1.as_uint64 : L1)){
+	    fprintf(stderr, "Syscall Failed At IP %"PRIu64"\n", IP);
+            vpu.return_status = 1;
+	    return 0xFFFFFFFFFFFFFFFF - IP;
+	}
         return 1;
     case INST_DISREG:
         printf("(%02"PRIx64"; u: %"PRIu64"; i: %"PRIi64"; f: %f)\n", R1.as_uint64, R1.as_uint64, R1.as_int64, R1.as_float64);
@@ -336,6 +335,7 @@ static inline int64_t perform_inst(Inst inst){
     
     default:
         fprintf(stderr, "[ERROR] Unknwon Instruction '%u' At Instuction Position %"PRIu64"\n", (unsigned int)inst, IP);
+	vpu.return_status = 1;
         return 0xFFFFFFFFFFFFFFFF - IP;
     }
 


### PR DESCRIPTION
1- fixed potentially dangerous arguments in some printf in the decompiler 2- more instructions can now take either registers or literal, because of this the PUSHV instruction is deprecated